### PR TITLE
use Julia 1.0.2

### DIFF
--- a/files/install-julia.sh
+++ b/files/install-julia.sh
@@ -21,7 +21,7 @@ case $VERSION in
         URL=https://julialang-s3.julialang.org/bin/linux/x64/0.7/julia-0.7.0-linux-x86_64.tar.gz
         ;;
     1.0)
-        URL=https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.1-linux-x86_64.tar.gz
+        URL=https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.2-linux-x86_64.tar.gz
         ;;
     nightly)
         URL=https://julialangnightlies-s3.julialang.org/bin/linux/x64/julia-latest-linux64.tar.gz


### PR DESCRIPTION
Upgrade the downloader to use Julia 1.0.2, the latest released version ATM. This is also included in the Docker image as the default.