### PR TITLE
remove extra fonts and latexmk

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ADD files/.ssh/ /root/.ssh/
 
 RUN apt-get update \
         && apt-get install --no-install-recommends -qq texlive-latex-base git \
-        texlive-pictures texlive-latex-extra texlive-fonts-extra latexmk pdf2svg \
+        texlive-pictures texlive-latex-extra pdf2svg \
         poppler-utils gnuplot-nox wget ca-certificates openssh-client rsync file \
         && /test/install-julia.sh 1.1 \
         && chmod 700 /root/.ssh && chmod 600 /root/.ssh/*


### PR DESCRIPTION
Fonts double the image size, latexmk is not needed for PGFPlotsX.

With hindsight, this was not a good idea. Reverts #12 and part of #11.