### PR TITLE
Generalize install-julia.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
         && apt-get install --no-install-recommends -qq texlive-latex-base git \
         texlive-pictures texlive-latex-extra pdf2svg \
         poppler-utils gnuplot-nox wget ca-certificates openssh-client rsync file \
-        && /test/install-julia.sh 1.1 \
+        && /test/install-julia.sh 1.2 \
         && chmod 700 /root/.ssh && chmod 600 /root/.ssh/*
 
 ENV NAME texlive-julia-docker

--- a/files/install-julia.sh
+++ b/files/install-julia.sh
@@ -6,8 +6,12 @@ use as
 
    install-julia.sh version
 
-to download and extract binaries in /test/julia-<version>. For valid
-versions, see the source.
+to download and extract binaries in /test/julia-<version>.
+<version> can be
+
+    1) a complete version number of the form v#.#.# (or #.#.#);
+    2) a version number of the form v#.# (or #.#);
+    3) nightly
 
 The binary will be at /test/julia-<version>/bin/julia.
 END
@@ -16,23 +20,24 @@ fi
 
 VERSION=$1
 
-case $VERSION in
-    0.7)
-        URL=https://julialang-s3.julialang.org/bin/linux/x64/0.7/julia-0.7.0-linux-x86_64.tar.gz
-        ;;
-    1.0)
-        URL=https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.4-linux-x86_64.tar.gz
-        ;;
-    1.1)
-        URL=https://julialang-s3.julialang.org/bin/linux/x64/1.1/julia-1.1.1-linux-x86_64.tar.gz
-        ;;
-    nightly)
-        URL=https://julialangnightlies-s3.julialang.org/bin/linux/x64/julia-latest-linux64.tar.gz
-        ;;
-    *)
-        echo "Unknown Julia version '$1'."
-        exit 1
-esac
+if [[ $VERSION = nightly ]]; then
+    URL=https://julialangnightlies-s3.julialang.org/bin/linux/x64/julia-latest-linux64.tar.gz
+elif [[ $VERSION =~ v?([0-9]+).([0-9]+).([0-9]+) ]]; then
+    MAJOR=${BASH_REMATCH[1]}
+    MINOR=${BASH_REMATCH[2]}
+    PATCH=${BASH_REMATCH[3]}
+    TARBALL=$MAJOR.$MINOR/julia-$MAJOR.$MINOR.$PATCH-linux-x86_64.tar.gz
+    URL=https://julialang-s3.julialang.org/bin/linux/x64/$TARBALL
+elif [[ $VERSION =~ v?([0-9]+).([0-9]+) ]]; then
+    MAJOR=${BASH_REMATCH[1]}
+    MINOR=${BASH_REMATCH[2]}
+    TARBALL=$MAJOR.$MINOR/julia-$MAJOR.$MINOR-latest-linux-x86_64.tar.gz
+    URL=https://julialang-s3.julialang.org/bin/linux/x64/$TARBALL
+else
+    echo "Could not parse input as a valid version."
+    exit 1
+fi
+
 
 DEST=/test/julia-$1/
 


### PR DESCRIPTION
 Generalize `install-julia.sh` to take any valid version number.