### PR TITLE
Figure out the minor version for major Julia versions.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ADD files/install-julia.sh /test/install-julia.sh
 ADD files/.ssh/ /root/.ssh/
 ADD files/latex-tests/ /test/latex-tests/
 
-RUN apt-get update \
+RUN echo "UTC" > /etc/timezone && apt-get update \
         && apt-get install --no-install-recommends -qq texlive-latex-base git \
         texlive-luatex texlive-pictures texlive-latex-extra pdf2svg \
         poppler-utils gnuplot-nox wget ca-certificates openssh-client rsync file \

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ ADD files/install-julia.sh /test/install-julia.sh
 ADD files/.ssh/ /root/.ssh/
 ADD files/latex-tests/ /test/latex-tests/
 
-RUN echo "UTC" > /etc/timezone && apt-get update \
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
         && apt-get install --no-install-recommends -qq texlive-latex-base git \
         texlive-luatex texlive-pictures texlive-latex-extra pdf2svg \
         poppler-utils gnuplot-nox wget ca-certificates openssh-client rsync file \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 MAINTAINER Tamas K. Papp <tkpapp@gmail.com>
 
 WORKDIR /test
@@ -11,7 +11,7 @@ RUN apt-get update \
         && apt-get install --no-install-recommends -qq texlive-latex-base git \
         texlive-luatex texlive-pictures texlive-latex-extra pdf2svg \
         poppler-utils gnuplot-nox wget ca-certificates openssh-client rsync file \
-        && /test/install-julia.sh 1.5 \
+        && /test/install-julia.sh 1 \
         && chmod 700 /root/.ssh && chmod 600 /root/.ssh/*
 
 ENV NAME texlive-julia-docker

--- a/README.md
+++ b/README.md
@@ -11,16 +11,22 @@ For testing Julia packages that rely on [TeXLive](https://tug.org/texlive/). It 
 Call `docker` as something like
 
 ```sh
-docker run -ti -a STDOUT -a STDIN -a STDERR -v .:/mnt texlive-julia-minimal /mnt/test-script.sh 1.0
+docker run -ti -a STDOUT -a STDIN -a STDERR -v .:/mnt texlive-julia-minimal /mnt/test-script.sh 1
 ```
 
 ie
 
 1. the source for the package is mounted at `/mnt` in the container (this is hardcoded into the scripts)
 
-2. `1.0` is the version, see [`files/install-julia.sh`](files/install-julia.sh) for alternatives,
+2. `1` is the version (see [`files/install-julia.sh`](files/install-julia.sh) for alternatives).
+   
+   This installs Julia, with the binary located at
+   ```sh
+   /test/julia-$JULIAVER/bin/julia
+   ```
 
 3. `test-script.sh` comes from your repository.
+
 
 ## What's in the image
 
@@ -35,3 +41,11 @@ Scripts for building, generation and deployment are in [`local/`](local/). See t
 ## Files for populating the repo
 
 See [their documentation](files/README.md).
+
+## Updating versions
+
+1. Minor versions of Julia need to be updated manually for each release in [`files/install-julia.sh`](files/install-julia.sh).
+
+2. New Ubuntu releases should be updated in the [`Dockerfile`](Dockerfile).
+
+For either, just make a trivial pull request, and it will be merged once CI completes.

--- a/files/install-julia.sh
+++ b/files/install-julia.sh
@@ -19,6 +19,10 @@ END
     exit 1
 fi
 
+# TODO: This needs to be manually updated until something like
+# https://github.com/JuliaLang/julia/issues/33817 has been resolved
+LATEST_V1="1.5"
+
 VERSION=$1
 
 if [[ $VERSION = nightly ]]; then
@@ -37,7 +41,7 @@ elif [[ $VERSION =~ v?([0-9]+).([0-9]+) ]]; then
 elif [[ $VERSION =~ v?([0-9]+) ]]; then
     MAJOR=${BASH_REMATCH[1]}
     if (( MAJOR == 1 )); then
-        MINOR = 5              # NOTE: update this manually for each release
+        MINOR=$LATEST_V1
     else
         echo "Don't know the latest minor version for Julia v$MAJOR."
     fi

--- a/files/install-julia.sh
+++ b/files/install-julia.sh
@@ -42,7 +42,7 @@ elif [[ $VERSION =~ v?([0-9]+) ]]; then
         echo "Don't know the latest minor version for Julia v$MAJOR."
     fi
     TARBALL=$MAJOR.$MINOR/julia-$MAJOR.$MINOR-latest-linux-x86_64.tar.gz
-    URL=https://julialang-s3.julialang.or1g/bin/linux/x64/$TARBALL
+    URL=https://julialang-s3.julialang.org/bin/linux/x64/$TARBALL
 else
     echo "Could not parse input as a valid version."
     exit 1

--- a/files/install-julia.sh
+++ b/files/install-julia.sh
@@ -21,7 +21,7 @@ fi
 
 # TODO: This needs to be manually updated until something like
 # https://github.com/JuliaLang/julia/issues/33817 has been resolved
-LATEST_V1="1.5"
+LATEST_V1_MINOR="5"
 
 VERSION=$1
 
@@ -41,7 +41,7 @@ elif [[ $VERSION =~ v?([0-9]+).([0-9]+) ]]; then
 elif [[ $VERSION =~ v?([0-9]+) ]]; then
     MAJOR=${BASH_REMATCH[1]}
     if (( MAJOR == 1 )); then
-        MINOR=$LATEST_V1
+        MINOR=$LATEST_V1_MINOR
     else
         echo "Don't know the latest minor version for Julia v$MAJOR."
     fi

--- a/files/install-julia.sh
+++ b/files/install-julia.sh
@@ -11,6 +11,7 @@ to download and extract binaries in /test/julia-<version>.
 
     1) a complete version number of the form v#.#.# (or #.#.#);
     2) a version number of the form v#.# (or #.#);
+    3) a version number of the form v# (or #);
     3) nightly
 
 The binary will be at /test/julia-<version>/bin/julia.
@@ -33,13 +34,21 @@ elif [[ $VERSION =~ v?([0-9]+).([0-9]+) ]]; then
     MINOR=${BASH_REMATCH[2]}
     TARBALL=$MAJOR.$MINOR/julia-$MAJOR.$MINOR-latest-linux-x86_64.tar.gz
     URL=https://julialang-s3.julialang.org/bin/linux/x64/$TARBALL
+elif [[ $VERSION =~ v?([0-9]+) ]]; then
+    MAJOR=${BASH_REMATCH[1]}
+    if (( MAJOR == 1 )); then
+        MINOR = 5              # NOTE: update this manually for each release
+    else
+        echo "Don't know the latest minor version for Julia v$MAJOR."
+    fi
+    TARBALL=$MAJOR.$MINOR/julia-$MAJOR.$MINOR-latest-linux-x86_64.tar.gz
+    URL=https://julialang-s3.julialang.or1g/bin/linux/x64/$TARBALL
 else
     echo "Could not parse input as a valid version."
     exit 1
 fi
 
-
-DEST=/test/julia-$1/
+DEST=/test/julia-$VERSION/
 
 if [ -d $DEST ]; then
     echo "Julia $VERSION is already available, not downloading."

--- a/files/latex-tests/test-script-inner.sh
+++ b/files/latex-tests/test-script-inner.sh
@@ -3,6 +3,9 @@
 # This script is run *inside* the Docker image, to test the relevant functionionality.
 set -e
 
+/test/install-julia.sh 1         # installation should work
+/test/julia-1/bin/julia -e '1+1' # installed nightly should work
+
 /test/install-julia.sh 1.0         # installation should work
 /test/julia-1.0/bin/julia -e '1+1' # should be installed
 
@@ -13,7 +16,13 @@ set -e
 /test/julia-1.1/bin/julia -e '1+1' # should be installed
 
 /test/install-julia.sh 1.3         # installation should work
-/test/julia-1.1/bin/julia -e '1+1' # should be installed
+/test/julia-1.3/bin/julia -e '1+1' # should be installed
+
+/test/install-julia.sh 1.4         # installation should work
+/test/julia-1.4/bin/julia -e '1+1' # should be installed
+
+/test/install-julia.sh 1.5         # installation should work
+/test/julia-1.5/bin/julia -e '1+1' # should be installed
 
 /test/install-julia.sh nightly         # installation should work
 /test/julia-nightly/bin/julia -e '1+1' # installed nightly should work


### PR DESCRIPTION
1. Figure out the minor version for major Julia versions (fixes #23).

2. Use Ubuntu 20.04.

3. Document version bumps in the README.